### PR TITLE
Allow using raw.githubusercontent URLs as spec source

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -62,8 +62,10 @@ async function getModifiedResponse(request) {
       .replace("</head>", `<script>${respecConfig}</script></head>`)
       .replace("</head>", `<script>${previewMarkerInjector}</script></head>`)
       .replace(respecScript, version.href);
+    const modifiedHeaders = new Headers(res.headers);
+    modifiedHeaders.set('Content-Type', 'text/html');
     return new Response(modifiedHTML, {
-      headers: res.headers,
+      headers: modifiedHeaders,
       status: res.status,
     });
   } catch (error) {


### PR DESCRIPTION
raw.githubusercontent.com returns text/plain responses, so this script has to force them to text/html in order to render them.